### PR TITLE
Brakemanを最新版に更新

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ group :development, :test do
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
-  gem "brakeman", require: false
+  gem "brakeman", "~> 8.0", require: false
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.21.1)
       msgpack (~> 1.2)
-    brakeman (8.0.1)
+    brakeman (8.0.2)
       racc
     builder (3.3.0)
     capybara (3.40.0)
@@ -337,7 +337,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
-  brakeman
+  brakeman (~> 8.0)
   capybara
   debug
   devise


### PR DESCRIPTION
### 概要
CIで使用しているBrakemanを最新版に更新しました。

### 変更内容
- GemfileのBrakemanを最新版（8系）に更新


### 補足
古いバージョン警告によるCIエラーを解消するために更新しています