### PR TITLE
fix: CIでtailwind CSSがビルドされない問題を修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,11 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
+      - name: Build Tailwind CSS
+        env:
+          RAILS_ENV: test
+        run: bin/rails tailwindcss:build
+        
       - name: Run tests
         env:
           RAILS_ENV: test

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,3 +1,5 @@
+@import "tailwindcss";
+
 /*
  * This is a manifest file that'll be compiled into application.css, which will include all the files
  * listed below.
@@ -10,6 +12,6 @@
  * files in this directory. Styles in this file should be added after the last require_* statement.
  * It is generally better to create a new file per style scope.
  *
- *= require_tree .
+ *= require tailwind
  *= require_self
  */

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,1 +1,0 @@
-@import "tailwindcss";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,6 @@
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
-    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>


### PR DESCRIPTION
### 概要
CI環境でTailwind CSSがビルドされず、テストが失敗していた問題を修正しました。
あわせて、CSSのエントリーポイントをapplication.cssに統一しました。

### 変更内容
- CIにTailwind CSSのビルドステップを追加
- Tailwind CSSの読み込みをapplication.css経由に整理