### PR TITLE
ヘッダー実装の初期設定を追加

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+
 
 /*
  * This is a manifest file that'll be compiled into application.css, which will include all the files

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,12 +13,14 @@
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
+    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
 
   <body>
-    <main class="mt-28">
+      <%= render 'shared/header' %>
+    <main>
       <%= yield %>
     </main>
     <% flash.each do |message_type, message| %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,17 @@
+<% header_stats ||= { saved: 0, today_total: 0, target: 0 } %>
+
+<div class="grid grid-cols-2 md:grid-cols-4 gap-2 w-full">
+  <% items = [
+    ["日付", l(Date.current)],
+    ["貯金額", "#{header_stats[:saved]} kcal"],
+    ["本日の総カロリー", "#{header_stats[:today_total]} kcal"],
+    ["目標貯金カロリー", "#{header_stats[:target]} kcal"],
+  ] %>
+
+  <% items.each do |label, value| %>
+    <div class="border border-gray-300 rounded-md bg-white px-4 py-3 min-h-[72px]">
+      <div class="text-xs text-gray-500"><%= label %></div>
+      <div class="text-lg font-semibold"><%= value %></div>
+    </div>
+  <% end %>
+</div>


### PR DESCRIPTION
## 概要
ログイン後トップ画面に表示するヘッダー（サマリー表示）の雛形を作成しました。
あわせてTailwindのビルド設定を修正し、スタイルが正しく反映されるようにしました。

## 変更内容
- shared/_header.html.erb を作成
- layoutにヘッダーを組み込み
- Tailwindのビルド設定を修正
- application.css を整理

## 確認方法
- ログイン後トップ画面を表示
- ヘッダーが横並びで表示されること
- Tailwindのスタイルが反映されていること

 close #20