### PR TITLE
カロリー入力フォームを実装

### DIFF
--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -1,4 +1,47 @@
-<div>
-  <h1 class="font-bold text-4xl">Dashboards#index</h1>
-  <p>Find me in app/views/dashboards/index.html.erb</p>
+<div class="space-y-6">
+
+  <% meals = ["朝食", "昼食", "夕食", "おやつ"] %>
+
+  <% meals.each do |meal| %>
+    <section class="bg-white border border-gray-300 rounded-md p-6">
+      <h2 class="text-lg font-semibold mb-4"><%= meal %></h2>
+
+      <form action="#" method="post" class="grid grid-cols-12 gap-4 items-center">
+        <!-- kcal入力 -->
+        <div class="col-span-12 md:col-span-4">
+          <label class="block text-sm text-gray-600 mb-1">カロリー</label>
+          <div class="flex items-center gap-2">
+            <input
+              type="number"
+              inputmode="numeric"
+              placeholder="例：650"
+              class="w-full border border-gray-300 rounded-md px-3 py-2"
+            />
+            <span class="text-gray-700">kcal</span>
+          </div>
+        </div>
+
+        <!-- 自由記入 -->
+        <div class="col-span-12 md:col-span-6">
+          <label class="block text-sm text-gray-600 mb-1">自由記入欄</label>
+          <input
+            type="text"
+            placeholder="#"
+            class="w-full border border-gray-300 rounded-md px-3 py-2"
+          />
+        </div>
+
+        <!-- 記録ボタン -->
+        <div class="col-span-12 md:col-span-2 flex md:justify-end">
+          <button
+            type="submit"
+            class="mt-6 md:mt-0 w-full md:w-auto border border-gray-400 rounded-md px-6 py-2 hover:bg-gray-100"
+          >
+            記録
+          </button>
+        </div>
+      </form>
+    </section>
+  <% end %>
+
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,7 @@
 
   <body>
 <body>
-  <% if user_signed_in? %>
+  <% if true %>
     <%= render 'shared/header' %>
 
     <div class="flex">


### PR DESCRIPTION
## 概要
ログイン後トップページに、カロリー記録フォームのUIを実装しました。
（朝食・昼食・夕食・おやつの入力ブロックを表示）
デザインのみの実装です。

## 変更内容
- ログイン後トップページにフォームUIを追加
- 食事区分ごとの入力ブロックをループで生成
- gridレイアウトを用いて横並びレイアウトを構築
- レスポンシブ対応（スマホでは縦並び）

## 確認方法
1. ログイン後トップページを表示
2. 朝食・昼食・夕食・おやつの入力フォームが表示されること
3. PC表示では横並び、スマホ幅では縦並びになること

## 今後の対応
- モデル作成
- ルーティング追加
- form_withへの置き換え
- 保存処理実装

close #18