### PR TITLE
feat:LINEログイン機能を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ end
 
 gem "devise"
 gem "omniauth-google-oauth2"
+gem "omniauth-line-v2"
 gem "omniauth-rails_csrf_protection"
 
 gem "devise-i18n"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,6 +215,9 @@ GEM
       oauth2 (~> 2.0)
       omniauth (~> 2.0)
       omniauth-oauth2 (~> 1.8)
+    omniauth-line-v2 (2.0.0)
+      omniauth (~> 2.0)
+      omniauth-oauth2 (~> 1.8)
     omniauth-oauth2 (1.9.0)
       oauth2 (>= 2.0.2, < 3)
       omniauth (~> 2.0)
@@ -419,6 +422,7 @@ DEPENDENCIES
   jbuilder
   letter_opener_web
   omniauth-google-oauth2
+  omniauth-line-v2
   omniauth-rails_csrf_protection
   pg (~> 1.1)
   puma (>= 5.0)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,5 +1,5 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
-    skip_before_action :verify_authenticity_token, only: [:google_oauth2, :line]
+    skip_before_action :verify_authenticity_token, only: [ :google_oauth2, :line ]
 
     def google_oauth2
         @user = User.from_omniauth(request.env["omniauth.auth"])

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,5 +1,5 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
-    skip_before_action :verify_authenticity_token, only: :google_oauth2
+    skip_before_action :verify_authenticity_token, only: [:google_oauth2, :line]
 
     def google_oauth2
         @user = User.from_omniauth(request.env["omniauth.auth"])
@@ -13,7 +13,19 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
         end
     end
 
+    def line
+        @user = User.from_omniauth(request.env["omniauth.auth"])
+
+        if @user.persisted?
+            sign_in_and_redirect @user, event: :authentication
+            set_flash_message(:notice, :success, kind: "LINE") if is_navigational_format?
+        else
+            session["devise.line_data"] = request.env["omniauth.auth"].except(:extra)
+            redirect_to new_user_registration_url, alert: @user.errors.full_messages.join("\n")
+        end
+    end
+
     def failure
-        redirect_to root_path, alert: "Google認証に失敗しました。"
+        redirect_to root_path, alert: "認証に失敗しました。"
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
-          :omniauthable, omniauth_providers: [ :google_oauth2 ]
+          :omniauthable, omniauth_providers: [ :google_oauth2, :line ]
 
   has_one :profile, dependent: :destroy
   has_many :calorie_records, dependent: :destroy

--- a/app/views/static_pages/before_login.html.erb
+++ b/app/views/static_pages/before_login.html.erb
@@ -25,7 +25,9 @@
 
     <%= button_to "Googleでログイン", user_google_oauth2_omniauth_authorize_path, method: :post, data: { turbo: false } %>
     <div class="flex flex-col items-center mt-4">
+    <!--
     <%= button_to "LINEでログイン", user_line_omniauth_authorize_path, method: :post, data: { turbo: false } %>
+    -->
       <%= link_to "ゲストとして試してみる →",
         guest_sign_in_path, data: { "turbo-method": :post },
         class: "text-gray-600 text-base underline hover:text-gray-800" %>

--- a/app/views/static_pages/before_login.html.erb
+++ b/app/views/static_pages/before_login.html.erb
@@ -25,6 +25,7 @@
 
     <%= button_to "Googleでログイン", user_google_oauth2_omniauth_authorize_path, method: :post, data: { turbo: false } %>
     <div class="flex flex-col items-center mt-4">
+    <%= button_to "LINEでログイン", user_line_omniauth_authorize_path, method: :post, data: { turbo: false } %>
       <%= link_to "ゲストとして試してみる →",
         guest_sign_in_path, data: { "turbo-method": :post },
         class: "text-gray-600 text-base underline hover:text-gray-800" %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -315,4 +315,5 @@ Devise.setup do |config|
   # config.sign_in_after_change_password = true
 
   config.omniauth :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"]
+  config.omniauth :line, ENV['LINE_CHANNEL_ID'], ENV['LINE_CHANNEL_SECRET']
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -315,7 +315,5 @@ Devise.setup do |config|
   # config.sign_in_after_change_password = true
 
   config.omniauth :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"]
-  config.omniauth :line, ENV['LINE_CHANNEL_ID'], ENV['LINE_CHANNEL_SECRET']
-    scope: "profile openid "
+  config.omniauth :line, ENV["LINE_CHANNEL_ID"], ENV["LINE_CHANNEL_SECRET"], scope: "profile openid"
 end
-  

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -316,4 +316,6 @@ Devise.setup do |config|
 
   config.omniauth :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"]
   config.omniauth :line, ENV['LINE_CHANNEL_ID'], ENV['LINE_CHANNEL_SECRET']
+    scope: "profile openid "
 end
+  


### PR DESCRIPTION
### 概要
LINE ログイン機能を実装しました。

### 内容
- omniauth-line-v2 gem を導入
- Devise に LINE OmniAuth 設定を追加
- User モデルに :line プロバイダーを追加
- OmniauthCallbacksController に LINE 認証処理を追加
- ログイン画面に LINE ログインボタンを追加（現在は非表示）

### 動作確認
- [x] LINE 認証フローが動作する（Tester 権限で確認）
- [x] LINE 認証成功後、CaloryBank に戻ってくる

### 未対応事項
- メールアドレス取得権限の申請（プライバシーポリシー作成後に対応）
- LINE ログインボタンは現在非表示にしてある

### 関連 Issue
Close #103 

### メモ
LINE ログインの基本実装は完了。ただし、メールアドレス取得には LINE Developers での申請が必要なため、プライバシーポリシーと利用規約を作成後に対応予定。それまでは LINE ログインボタンを非表示にする。