### PR TITLE
Feat/liff calorie records

### DIFF
--- a/app/controllers/calorie_records_controller.rb
+++ b/app/controllers/calorie_records_controller.rb
@@ -10,6 +10,12 @@ class CalorieRecordsController < ApplicationController
     @calorie_record = CalorieRecord.new
   end
 
+  def liff_new
+    @meal_type = params[:meal_type]
+    @calorie_record = CalorieRecord.new
+    render :new
+  end
+  
   def create
     record = current_user.calorie_records.find_or_initialize_by(
       eat_date: Date.current,

--- a/app/controllers/calorie_records_controller.rb
+++ b/app/controllers/calorie_records_controller.rb
@@ -15,7 +15,7 @@ class CalorieRecordsController < ApplicationController
     @calorie_record = CalorieRecord.new
     render :new
   end
-  
+
   def create
     record = current_user.calorie_records.find_or_initialize_by(
       eat_date: Date.current,

--- a/app/views/calorie_records/_form.html.erb
+++ b/app/views/calorie_records/_form.html.erb
@@ -1,49 +1,33 @@
 <%= form_with model: calorie_record, local: true do |f| %>
-  <%= f.hidden_field :meal_type, value: calorie_record.meal_type %>
+    <%= f.hidden_field :meal_type, value: meal_type %>
+    <%= f.hidden_field :image, value: calorie_record.cached_image_data %>
+  <div class="flex flex-col items-center space-y-4">
 
-  <div class="flex flex-wrap items-end gap-4">
-
-    <div class="w-full sm:w-auto">
-      <%= f.label :base_calorie, "カロリー", class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <div class="flex items-center gap-2">
-        <%= f.number_field :base_calorie,
-              inputmode: "numeric",
-              placeholder: "例：650",
-              class: "w-full sm:w-32 rounded-xl bg-white/50 border border-white/30 px-4 py-3 text-sm shadow-sm
-                      focus:outline-none focus:ring-2 focus:ring-indigo-400" %>
-        <span class="text-gray-700 text-sm">kcal</span>
-      </div>
+    <div class="w-full max-w-sm">
+      <%= f.label :base_calorie, "カロリー", class: "block mb-1 text-sm font-medium" %>
+      <%= f.text_field :base_calorie,
+      inputmode: "numeric",
+      class: "w-full border rounded px-3 py-2" %>
     </div>
 
-    <!-- ご飯 -->
-    <% unless calorie_record.meal_type == "snack" %>
-    <div class="w-full sm:w-auto">
-      <%= f.label :rice_bowls, class: "block text-sm font-medium text-gray-700 mb-1" do %>
-        <% if calorie_record.persisted? %>
-          <span class="text-gray-500 font-normal">ご飯 <%= calorie_record.rice_bowls %>杯 = <%= (calorie_record.rice_bowls.to_f * @rice_kcal_per_bowl).round %> kcal</span>
-        <% else %>
-          ご飯(杯) <span class="text-gray-500 font-normal"><%= @rice_kcal_per_bowl %> kcal/杯</span>
-        <% end %>
-      <% end %>
-      <%= f.number_field :rice_bowls, min: 0, placeholder: "1",
-            value: calorie_record.persisted? ? calorie_record.rice_bowls : 1,
-            class: "w-full sm:w-24 rounded-xl bg-white/50 border border-white/30 px-4 py-3 text-sm shadow-sm
-                    focus:outline-none focus:ring-2 focus:ring-indigo-400" %>
-    </div>
-  <% end %>
-    <!-- メモ -->
-    <div class="flex-1 min-w-40 w-full">
-      <%= f.label :memo, "メモ", class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= f.text_field :memo, placeholder: "例：外食した",
-            class: "w-full rounded-xl bg-white/50 border border-white/30 px-4 py-3 text-sm shadow-sm
-                    focus:outline-none focus:ring-2 focus:ring-indigo-400" %>
+    <div class="w-full max-w-sm">
+      <%= f.label :rice_bowls, "ご飯(杯)", class: "block mb-1 text-sm font-medium" %>
+      <%= f.number_field :rice_bowls, min: 0, class: "w-full border rounded px-3 py-2" %>
     </div>
 
-    <!-- ボタン -->
-    <div class="w-full sm:w-auto">
-      <%= f.submit(calorie_record.persisted? ? "更新する" : "記録",
-            class: "w-full sm:w-auto px-6 py-3 rounded-xl bg-indigo-600/90 text-white text-sm font-medium shadow-lg
-                    hover:bg-indigo-500 transition focus:outline-none focus:ring-2 focus:ring-indigo-300") %>
+    <div class="w-full max-w-sm">
+      <%= f.label :memo, "メモ", class: "block mb-1 text-sm font-medium" %>
+      <%= f.text_area :memo, class: "w-full border rounded px-3 py-2" %>
     </div>
+
+    <div class="w-full max-w-sm">
+      <%= f.label :image, "画像", class: "block mb-1 text-sm font-medium" %>
+      <%= f.file_field :image, class: "w-full border rounded px-3 py-2" %>
+    </div>
+
+    <div class="w-full max-w-sm">
+      <%= f.submit "保存", class: "w-full bg-indigo-600 text-white py-2 rounded" %>
+    </div>
+
   </div>
 <% end %>

--- a/app/views/calorie_records/_form.old.html.erb
+++ b/app/views/calorie_records/_form.old.html.erb
@@ -1,0 +1,49 @@
+<%= form_with model: calorie_record, local: true do |f| %>
+  <%= f.hidden_field :meal_type, value: calorie_record.meal_type %>
+
+  <div class="flex flex-wrap items-end gap-4">
+
+    <div class="w-full sm:w-auto">
+      <%= f.label :base_calorie, "カロリー", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <div class="flex items-center gap-2">
+        <%= f.number_field :base_calorie,
+              inputmode: "numeric",
+              placeholder: "例：650",
+              class: "w-full sm:w-32 rounded-xl bg-white/50 border border-white/30 px-4 py-3 text-sm shadow-sm
+                      focus:outline-none focus:ring-2 focus:ring-indigo-400" %>
+        <span class="text-gray-700 text-sm">kcal</span>
+      </div>
+    </div>
+
+    <!-- ご飯 -->
+    <% unless calorie_record.meal_type == "snack" %>
+    <div class="w-full sm:w-auto">
+      <%= f.label :rice_bowls, class: "block text-sm font-medium text-gray-700 mb-1" do %>
+        <% if calorie_record.persisted? %>
+          <span class="text-gray-500 font-normal">ご飯 <%= calorie_record.rice_bowls %>杯 = <%= (calorie_record.rice_bowls.to_f * @rice_kcal_per_bowl).round %> kcal</span>
+        <% else %>
+          ご飯(杯) <span class="text-gray-500 font-normal"><%= @rice_kcal_per_bowl %> kcal/杯</span>
+        <% end %>
+      <% end %>
+      <%= f.number_field :rice_bowls, min: 0, placeholder: "1",
+            value: calorie_record.persisted? ? calorie_record.rice_bowls : 1,
+            class: "w-full sm:w-24 rounded-xl bg-white/50 border border-white/30 px-4 py-3 text-sm shadow-sm
+                    focus:outline-none focus:ring-2 focus:ring-indigo-400" %>
+    </div>
+  <% end %>
+    <!-- メモ -->
+    <div class="flex-1 min-w-40 w-full">
+      <%= f.label :memo, "メモ", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.text_field :memo, placeholder: "例：外食した",
+            class: "w-full rounded-xl bg-white/50 border border-white/30 px-4 py-3 text-sm shadow-sm
+                    focus:outline-none focus:ring-2 focus:ring-indigo-400" %>
+    </div>
+
+    <!-- ボタン -->
+    <div class="w-full sm:w-auto">
+      <%= f.submit(calorie_record.persisted? ? "更新する" : "記録",
+            class: "w-full sm:w-auto px-6 py-3 rounded-xl bg-indigo-600/90 text-white text-sm font-medium shadow-lg
+                    hover:bg-indigo-500 transition focus:outline-none focus:ring-2 focus:ring-indigo-300") %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/calorie_records/liff_new.html.erb
+++ b/app/views/calorie_records/liff_new.html.erb
@@ -1,0 +1,7 @@
+<h1 class="text-lg text-center font-bold mb-3">
+  <%= @meal_type %> のカロリー入力
+</h1>
+
+<div class="px-4">
+  <%= render "form", calorie_record: @calorie_record, meal_type: @meal_type %>
+</div>

--- a/app/views/calorie_records/new.html.erb
+++ b/app/views/calorie_records/new.html.erb
@@ -1,36 +1,4 @@
 <h1 class="text-xl text-center font-bold mb-4">
   <%= @meal_type %> のカロリー入力
 </h1>
-<%= form_with model: @calorie_record, local: true do |f| %>
-    <%= f.hidden_field :meal_type, value: @meal_type %>
-    <%= f.hidden_field :image, value: @calorie_record.cached_image_data %>
-  <div class="flex flex-col items-center space-y-4">
-
-    <div class="w-full max-w-sm">
-      <%= f.label :base_calorie, "カロリー", class: "block mb-1 text-sm font-medium" %>
-      <%= f.text_field :base_calorie,
-      inputmode: "numeric",
-      class: "w-full border rounded px-3 py-2" %>
-    </div>
-
-    <div class="w-full max-w-sm">
-      <%= f.label :rice_bowls, "ご飯(杯)", class: "block mb-1 text-sm font-medium" %>
-      <%= f.number_field :rice_bowls, min: 0, class: "w-full border rounded px-3 py-2" %>
-    </div>
-
-    <div class="w-full max-w-sm">
-      <%= f.label :memo, "メモ", class: "block mb-1 text-sm font-medium" %>
-      <%= f.text_area :memo, class: "w-full border rounded px-3 py-2" %>
-    </div>
-
-    <div class="w-full max-w-sm">
-      <%= f.label :image, "画像", class: "block mb-1 text-sm font-medium" %>
-      <%= f.file_field :image, class: "w-full border rounded px-3 py-2" %>
-    </div>
-
-    <div class="w-full max-w-sm">
-      <%= f.submit "保存", class: "w-full bg-indigo-600 text-white py-2 rounded" %>
-    </div>
-
-  </div>
-<% end %>
+<%= render "form", calorie_record: @calorie_record, meal_type: @meal_type %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "posts#index"
 
+  get "liff/calorie_records/new", to: "calorie_records#liff_new"
 
   authenticated :user do
     root "homes#index", as: :user_root


### PR DESCRIPTION
### 概要
LIFF アプリ用の専用ページとルートを追加しました。

### 内容
- カロリー入力フォームをパーシャル化（_form.html.erb）
- CalorieRecordsController に liff_new アクションを追加
- routes.rb に LIFF 用のルートを追加（/liff/calorie_records/new）
- LIFF 専用ビュー（liff_new.html.erb）を作成

### 動作確認
- [x] ローカルで /liff/calorie_records/new にアクセスして表示確認
- [x] LIFFアプリとしての動作確認
- [x] LIFFアプリ内で、カロリーの登録、保存を確認

### メモ
LIFF専用のページを作成しました。また、カロリー記録する機能は、
既存のcalorie_recordsコントローラーを使うことにしました。
しかし、newアクションだけは分けて書くようにしました。
今後、LIFF専用の拡張機能や動きが必要になった時には
専用のコントローラーを作成する予定です。


### 関連 Issue
close #93
close #102 