### PR TITLE
feat/add footer links

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,3 +1,7 @@
 class StaticPagesController < ApplicationController
     def top; end
+
+    def terms; end
+
+    def privacy; end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,5 +43,6 @@
         </div>
       <% end %>
   </div>
+    <%= render "shared/footer" %>
 </body>
 </html>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,7 +1,7 @@
 <footer class="bg-black/40 backdrop-blur text-white py-4">
   <div class="max-w-4xl mx-auto text-center">
     <%= link_to "プライバシーポリシー", "#", class: "text-sm text-white-300 hover:text-gray-500" %> |
-    <%= link_to "利用規約", "#", class: "text-sm text-white-300 hover:text-gray-500" %>
+    <%= link_to "利用規約", terms_path, class: "text-sm text-white-300 hover:text-gray-500" %>
     <p class="text-sm">© 2026 Calorie Bank</p>
   </div>
 </footer>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,0 +1,7 @@
+<footer class="bg-black/40 backdrop-blur text-white py-4">
+  <div class="max-w-4xl mx-auto text-center">
+    <%= link_to "プライバシーポリシー", "#", class: "text-sm text-white-300 hover:text-gray-500" %> |
+    <%= link_to "利用規約", "#", class: "text-sm text-white-300 hover:text-gray-500" %>
+    <p class="text-sm">© 2026 Calorie Bank</p>
+  </div>
+</footer>

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -1,0 +1,90 @@
+<div class="max-w-3xl mx-auto px-4 py-10 text-sm leading-relaxed">
+
+  <h1 class="text-2xl font-bold text-center mb-8">プライバシーポリシー</h1>
+
+  <p class="mb-6">
+    Calorie_Bank（以下「本サービス」といいます。）は、ユーザーの個人情報を適切に取り扱うことを重要な責務と考えています。本ポリシーでは、本サービスにおける情報の取得、利用および管理について定めます。
+  </p>
+
+  <section class="mb-6">
+    <h2 class="text-lg font-bold mb-2">第1条（取得する情報）</h2>
+    <p>本サービスでは、以下の情報を取得する場合があります。</p>
+    <ul class="list-disc pl-6 mt-2 space-y-1">
+      <li>メールアドレス</li>
+      <li>ユーザー名（ニックネーム）</li>
+      <li>投稿情報（カロリー記録、画像等）</li>
+      <li>外部サービス連携情報（LINEログイン等）</li>
+      <li>Cookie等の識別情報</li>
+      <li>アクセスログ情報（IPアドレス、利用環境等）</li>
+    </ul>
+  </section>
+
+  <section class="mb-6">
+    <h2 class="text-lg font-bold mb-2">第2条（利用目的）</h2>
+    <p>取得した情報は、以下の目的で利用します。</p>
+    <ul class="list-disc pl-6 mt-2 space-y-1">
+      <li>ユーザー登録および本人確認のため</li>
+      <li>サービスの提供および機能改善のため</li>
+      <li>ユーザーの利用履歴の管理のため</li>
+      <li>お問い合わせ対応のため</li>
+      <li>不正利用の防止および対応のため</li>
+    </ul>
+  </section>
+
+  <section class="mb-6">
+    <h2 class="text-lg font-bold mb-2">第3条（Cookieの利用）</h2>
+    <p>
+      本サービスでは、ログイン状態の維持や利便性向上のためにCookieを使用する場合があります。
+    </p>
+  </section>
+
+  <section class="mb-6">
+    <h2 class="text-lg font-bold mb-2">第4条（第三者提供）</h2>
+    <p>
+      本サービスは、法令に基づく場合を除き、ユーザーの同意なく個人情報を第三者に提供することはありません。
+    </p>
+  </section>
+
+  <section class="mb-6">
+    <h2 class="text-lg font-bold mb-2">第5条（外部サービスの利用）</h2>
+    <p>
+      本サービスでは、LINEログイン等の外部サービスを利用しています。外部サービスにおける個人情報の取扱いについては、各サービスのプライバシーポリシーをご確認ください。
+    </p>
+  </section>
+
+  <section class="mb-6">
+    <h2 class="text-lg font-bold mb-2">第6条（情報の管理）</h2>
+    <p>
+      本サービスは、ユーザー情報の漏洩、紛失、改ざんを防止するために適切なセキュリティ対策を講じます。
+    </p>
+  </section>
+
+  <section class="mb-6">
+    <h2 class="text-lg font-bold mb-2">第7条（情報の変更・削除）</h2>
+    <p>
+      ユーザーは、自己の情報について変更または削除を求めることができます。詳細はお問い合わせフォームよりご連絡ください。
+    </p>
+  </section>
+
+  <section class="mb-6">
+    <h2 class="text-lg font-bold mb-2">第8条（ポリシーの変更）</h2>
+    <p>
+      本サービスは、必要に応じて本ポリシーの内容を変更することがあります。変更後の内容は本サービス上に掲載した時点から効力を生じます。
+    </p>
+  </section>
+
+  <section class="mb-6">
+    <h2 class="text-lg font-bold mb-2">第9条（準拠法）</h2>
+    <p>
+      本ポリシーは日本法に準拠して解釈されます。
+    </p>
+  </section>
+
+  <section>
+    <h2 class="text-lg font-bold mb-2">第10条（お問い合わせ）</h2>
+    <p>
+      本サービスに関するお問い合わせは、アプリ内のお問い合わせフォームよりご連絡ください。
+    </p>
+  </section>
+
+</div>

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -1,4 +1,5 @@
-<div class="max-w-3xl mx-auto px-4 py-10 text-sm leading-relaxed">
+<div class="bg-[#F8F5EF] min-h-screen px-4 py-12">
+ <div class="max-w-2xl mx-auto bg-white/90 rounded-xl shadow-sm px-6 py-10 text-sm leading-7 text-gray-800">
 
   <h1 class="text-2xl font-bold text-center mb-8">プライバシーポリシー</h1>
 
@@ -86,5 +87,5 @@
       本サービスに関するお問い合わせは、アプリ内のお問い合わせフォームよりご連絡ください。
     </p>
   </section>
-
+ </div>
 </div>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -1,0 +1,99 @@
+<div class="max-w-3xl mx-auto px-4 py-10 text-sm leading-relaxed">
+  <h1 class="text-2xl font-bold text-center mb-8">利用規約</h1>
+
+  <p class="mb-6">
+    本利用規約（以下「本規約」といいます。）は、Calorie_Bank（以下「本サービス」といいます。）が提供するサービスの利用条件を定めるものです。ユーザーは、本サービスを利用することにより、本規約に同意したものとみなされます。
+  </p>
+
+  <section class="mb-6">
+    <h2 class="text-lg font-bold mb-2">第1条（適用）</h2>
+    <p>本規約は、本サービスの提供条件および本サービスの利用に関する本サービスとユーザーとの間の権利義務関係を定めることを目的とし、すべてのユーザーに適用されます。</p>
+  </section>
+
+  <section class="mb-6">
+    <h2 class="text-lg font-bold mb-2">第2条（利用登録）</h2>
+    <ol class="list-decimal pl-6 space-y-1">
+      <li>ユーザーは、本サービスの定める方法により利用登録を行うものとします。</li>
+      <li>本サービスは、以下の場合には登録を拒否することがあります。</li>
+    </ol>
+    <ul class="list-disc pl-8 mt-2 space-y-1">
+      <li>虚偽の情報を申請した場合</li>
+      <li>過去に規約違反等により利用停止等の措置を受けたことがある場合</li>
+      <li>その他、本サービスが登録を適当でないと判断した場合</li>
+    </ul>
+  </section>
+
+  <section class="mb-6">
+    <h2 class="text-lg font-bold mb-2">第3条（アカウント管理）</h2>
+    <ol class="list-decimal pl-6 space-y-1">
+      <li>ユーザーは、自己の責任においてアカウント情報を適切に管理するものとします。</li>
+      <li>アカウントの不正使用によって生じた損害について、本サービスは一切の責任を負いません。</li>
+    </ol>
+  </section>
+
+    <section class="mb-6">
+    <h2 class="text-lg font-bold mb-2">第4条（禁止事項）</h2>
+    <ul class="list-disc pl-6 space-y-1">
+      <li>法令または公序良俗に違反する行為</li>
+      <li>犯罪行為またはこれに関連する行為</li>
+      <li>他のユーザーまたは第三者の知的財産権、プライバシー等を侵害する行為</li>
+      <li>虚偽の情報の登録、誹謗中傷、差別的表現の投稿</li>
+      <li>本サービスのサーバーやネットワークに過度な負荷をかける行為</li>
+      <li>その他、本サービスが不適切と判断する行為</li>
+    </ul>
+  </section>
+
+  <section class="mb-6">
+    <h2 class="text-lg font-bold mb-2">第5条（投稿コンテンツの取扱い）</h2>
+    <ol class="list-decimal pl-6 space-y-1">
+      <li>投稿コンテンツの著作権は、当該ユーザーに帰属します。</li>
+      <li>ユーザーは、本サービスに対し、サービス運営・表示・改善のために必要な範囲で、投稿コンテンツを無償で利用する権利を許諾するものとします。</li>
+    </ol>
+  </section>
+
+  <section class="mb-6">
+    <h2 class="text-lg font-bold mb-2">第6条（サービスの提供の停止）</h2>
+    <p>本サービスは、保守点検、不可抗力、その他運営上必要と判断した場合には、事前の通知なくサービスの全部または一部の提供を停止または中断することがあります。</p>
+  </section>
+
+  <section class="mb-6">
+    <h2 class="text-lg font-bold mb-2">第7条（利用制限および登録抹消）</h2>
+    <p>本サービスは、ユーザーが本規約に違反した場合、事前の通知なくアカウントの利用制限または削除を行うことができます。</p>
+  </section>
+
+  <section class="mb-6">
+    <h2 class="text-lg font-bold mb-2">第8条（退会）</h2>
+    <p>ユーザーは、本サービスの定める方法により、退会の申請を行うことができます。退会手続きの詳細については、アプリ内のお問い合わせフォームよりご連絡ください。</p>
+  </section>
+
+  <section class="mb-6">
+    <h2 class="text-lg font-bold mb-2">第9条（免責事項）</h2>
+    <p>本サービスは、本サービスの内容の正確性・有用性等について保証するものではありません。本サービスの利用により生じた損害について、本サービスは一切の責任を負いません。</p>
+  </section>
+
+  <section class="mb-6">
+    <h2 class="text-lg font-bold mb-2">第10条（サービス内容の変更・終了）</h2>
+    <p>本サービスは、ユーザーに通知することなく、サービス内容の変更または提供の終了を行うことがあります。</p>
+  </section>
+
+  <section class="mb-6">
+    <h2 class="text-lg font-bold mb-2">第11条（規約の変更）</h2>
+    <p>本サービスは、必要と判断した場合には、本規約を変更することができます。変更後の規約は、本サービス上に掲載した時点から効力を生じるものとします。</p>
+  </section>
+
+  <section class="mb-6">
+    <h2 class="text-lg font-bold mb-2">第12条（個人情報の取扱い）</h2>
+    <p>本サービスは、個人情報を別途定めるプライバシーポリシーに従い適切に取り扱います。</p>
+  </section>
+
+  <section class="mb-6">
+    <h2 class="text-lg font-bold mb-2">第13条（準拠法・管轄）</h2>
+    <p>本規約は日本法に準拠し、本サービスに関して紛争が生じた場合には、運営所在地を管轄する裁判所を専属的合意管轄とします。</p>
+  </section>
+
+  <section>
+    <h2 class="text-lg font-bold mb-2">第14条（お問い合わせ）</h2>
+    <p>本サービスに関するお問い合わせは、アプリ内のお問い合わせフォームよりご連絡ください。</p>
+  </section>
+
+</div>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -1,4 +1,5 @@
-<div class="max-w-3xl mx-auto px-4 py-10 text-sm leading-relaxed">
+<div class="bg-[#F8F5EF] min-h-screen px-4 py-12">
+ <div class="max-w-2xl mx-auto bg-white/90 rounded-xl shadow-sm px-6 py-10 text-sm leading-7 text-gray-800">
   <h1 class="text-2xl font-bold text-center mb-8">利用規約</h1>
 
   <p class="mb-6">
@@ -66,9 +67,18 @@
     <p>ユーザーは、本サービスの定める方法により、退会の申請を行うことができます。退会手続きの詳細については、アプリ内のお問い合わせフォームよりご連絡ください。</p>
   </section>
 
-  <section class="mb-6">
-    <h2 class="text-lg font-bold mb-2">第9条（カロリー情報の正確性について）</h2>
-    <p>本サービスは、本サービスの内容の正確性・有用性等について保証するものではありません。本サービスの利用により生じた損害について、本サービスは一切の責任を負いません。</p>
+  <section class="mb-8">
+    <h2 class="text-lg font-bold mb-3">第9条（カロリー情報の正確性について）</h2>
+    <p class="mb-2">
+      本サービスでは、AI技術等を用いて食事のカロリーを推定する機能を提供しています。
+      当該カロリー値はあくまで参考値であり、その正確性・完全性を保証するものではありません。
+    </p>
+    <p class="mb-2">
+      ユーザーは、提示されたカロリー情報を利用する場合には、自己の責任において判断するものとし、必要に応じて医師その他の専門家にご相談ください。
+    </p>
+    <p>
+      本サービスは、当該情報の利用により生じたいかなる損害についても責任を負いません。
+    </p>
   </section>
 
   <section class="mb-6">
@@ -101,4 +111,5 @@
     <p>本サービスに関するお問い合わせは、アプリ内のお問い合わせフォームよりご連絡ください。</p>
   </section>
 
+ </div>
 </div>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -67,32 +67,37 @@
   </section>
 
   <section class="mb-6">
-    <h2 class="text-lg font-bold mb-2">第9条（免責事項）</h2>
+    <h2 class="text-lg font-bold mb-2">第9条（カロリー情報の正確性について）</h2>
     <p>本サービスは、本サービスの内容の正確性・有用性等について保証するものではありません。本サービスの利用により生じた損害について、本サービスは一切の責任を負いません。</p>
   </section>
 
   <section class="mb-6">
-    <h2 class="text-lg font-bold mb-2">第10条（サービス内容の変更・終了）</h2>
+    <h2 class="text-lg font-bold mb-2">第10条（免責事項）</h2>
+    <p>本サービスは、本サービスの内容の正確性・有用性等について保証するものではありません。本サービスの利用により生じた損害について、本サービスは一切の責任を負いません。</p>
+  </section>
+
+  <section class="mb-6">
+    <h2 class="text-lg font-bold mb-2">第11条（サービス内容の変更・終了）</h2>
     <p>本サービスは、ユーザーに通知することなく、サービス内容の変更または提供の終了を行うことがあります。</p>
   </section>
 
   <section class="mb-6">
-    <h2 class="text-lg font-bold mb-2">第11条（規約の変更）</h2>
+    <h2 class="text-lg font-bold mb-2">第12条（規約の変更）</h2>
     <p>本サービスは、必要と判断した場合には、本規約を変更することができます。変更後の規約は、本サービス上に掲載した時点から効力を生じるものとします。</p>
   </section>
 
   <section class="mb-6">
-    <h2 class="text-lg font-bold mb-2">第12条（個人情報の取扱い）</h2>
+    <h2 class="text-lg font-bold mb-2">第13条（個人情報の取扱い）</h2>
     <p>本サービスは、個人情報を別途定めるプライバシーポリシーに従い適切に取り扱います。</p>
   </section>
 
   <section class="mb-6">
-    <h2 class="text-lg font-bold mb-2">第13条（準拠法・管轄）</h2>
+    <h2 class="text-lg font-bold mb-2">第14条（準拠法・管轄）</h2>
     <p>本規約は日本法に準拠し、本サービスに関して紛争が生じた場合には、運営所在地を管轄する裁判所を専属的合意管轄とします。</p>
   </section>
 
   <section>
-    <h2 class="text-lg font-bold mb-2">第14条（お問い合わせ）</h2>
+    <h2 class="text-lg font-bold mb-2">第15条（お問い合わせ）</h2>
     <p>本サービスに関するお問い合わせは、アプリ内のお問い合わせフォームよりご連絡ください。</p>
   </section>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
   # root "posts#index"
 
   get "liff/calorie_records/new", to: "calorie_records#liff_new"
+  get "terms", to: "pages#terms"
 
   authenticated :user do
     root "homes#index", as: :user_root

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,8 @@ Rails.application.routes.draw do
   # root "posts#index"
 
   get "liff/calorie_records/new", to: "calorie_records#liff_new"
-  get "terms", to: "pages#terms"
+  get "terms", to: "static_pages#terms"
+  get "privacy", to: "static_pages#privacy"
 
   authenticated :user do
     root "homes#index", as: :user_root


### PR DESCRIPTION
### 概要
ログイン前トップページにフッターを実装し、利用規約・プライバシーポリシーへの導線を追加しました。

### 変更内容
- フッターコンポーネントを追加
- 利用規約ページへのリンクを追加
- プライバシーポリシーページへのリンクを追加

### 変更理由
ユーザーがいつでも規約・ポリシーを確認できるようにするため。

### 確認方法
- トップページにアクセス
- フッターが表示されることを確認
- 各リンクから利用規約・プライバシーポリシーページに遷移できることを確認

### 補足
ログイン前ページのみで表示しています。

close #95 