### PR TITLE
feat:　ハンバーガーメニューを実装

### DIFF
--- a/app/views/shared/_nav_unauthenticated.html.erb
+++ b/app/views/shared/_nav_unauthenticated.html.erb
@@ -1,4 +1,22 @@
-<nav>
-    <%= link_to "ログイン", new_user_session_path, class: "text-gray-600 hover:text-gray-800 text-right" %>
-    <%= link_to "新規登録", new_user_registration_path, class: "ml-4 text-gray-600 hover:text-gray-800 text-right" %>
+<nav class="relative">
+  <!-- チェックボックス本体は隠す -->
+  <input type="checkbox" id="menu-toggle" class="peer hidden">
+
+  <!-- ハンバーガーボタン -->
+  <label for="menu-toggle"
+         class="md:hidden cursor-pointer text-gray-700 px-3 py-2 border rounded">
+    メニュー
+  </label>
+
+  <!-- PC用ナビ -->
+  <div class="hidden md:flex items-center">
+    <%= link_to "ログイン", new_user_session_path, class: "text-gray-600 hover:text-gray-800" %>
+    <%= link_to "新規登録", new_user_registration_path, class: "ml-4 text-gray-600 hover:text-gray-800" %>
+  </div>
+
+  <!-- モバイル用ドロップダウン -->
+  <div class="hidden peer-checked:block md:hidden absolute right-0 mt-2 w-40 bg-white border rounded shadow-lg z-50">
+    <%= link_to "ログイン", new_user_session_path, class: "block px-4 py-3 text-gray-700 hover:bg-gray-100" %>
+    <%= link_to "新規登録", new_user_registration_path, class: "block px-4 py-3 text-gray-700 hover:bg-gray-100" %>
+  </div>
 </nav>


### PR DESCRIPTION
### 概要
ヘッダーにレスポンシブ対応のハンバーガーメニューを実装しました。

### 変更内容
- PC 画面：ナビゲーションリンクを横並びで表示
- モバイル画面：ハンバーガーボタンをタップすると、ドロップダウンメニューが開く形式に変更
- JavaScript を使わず、CSS のみで開閉を実装（peer + checkbox の手法）

### 動作確認
- [x] PC 画面（768px 以上）でナビが表示される
- [x] モバイル画面（768px 未満）でハンバーガーボタンが表示される
- [x] ハンバーガーボタンをタップすると、ドロップダウンメニューが開く

### 関連 Issue
close #80 