### PR TITLE
feat: ログイン後トップページのUIを改善

### DIFF
--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -1,20 +1,35 @@
-<div class="grid grid-cols-2 gap-3">
-  <% @meals.each do |label, meal_type| %>
-    <section class="rounded-2xl border border-white/30 bg-white/35 backdrop-blur-md shadow-lg p-6">
-    <div class="flex justify-between items-center mb-4">
-      <h2 class="text-lg font-semibold mb-4 text-gray-900"><%= label %></h2>
-      <%= link_to "記録する", new_calorie_record_path(meal_type: meal_type), class: "text-sm text-indigo-600 hover:text-indigo-800" %>
-    </div>
-    <% data = @calorie_records.find { |r| r.meal_type == meal_type.to_s } %>
-    <% if data.present? %>
-        <p><%= data.calorie %> kcal</p>
-        <p><%= data.memo %></p>
-        <% if data.image.present? %>
-          <p><%= image_tag data.image_url, class: "mt-2 rounded w-full max-h-48 object-contain" %></p>
+<div class="max-w-4xl mx-auto px-4 py-8">
+  <%= render "shared/header_old" %>
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+    <% @meals.each do |label, meal_type| %>
+      <section class="rounded-2xl border border-white/30 bg-white/80 backdrop-blur-md shadow-lg p-6">
+        <div class="flex justify-between items-center mb-4">
+          <h2 class="text-lg font-semibold text-gray-900"><%= label %></h2>
+
+          <%= link_to "記録する",
+            new_calorie_record_path(meal_type: meal_type),
+            class: "text-sm font-medium text-orange-500 hover:text-orange-600" %>
+        </div>
+
+        <% data = @calorie_records.find { |r| r.meal_type == meal_type.to_s } %>
+
+        <% if data.present? %>
+          <p class="text-2xl font-bold text-gray-900">
+            <%= data.calorie %>
+            <span class="text-sm font-medium text-gray-500">kcal</span>
+          </p>
+
+          <% if data.memo.present? %>
+            <p class="mt-2 text-sm text-gray-600"><%= data.memo %></p>
+          <% end %>
+
+          <% if data.image.present? %>
+            <p><%= image_tag data.image_url, class: "mt-4 rounded-xl w-full max-h-48 object-contain" %></p>
+          <% end %>
+        <% else %>
+          <p class="text-sm text-gray-500">記録がありません</p>
         <% end %>
-    <% else %>
-        <p>記録がありません</p>
+      </section>
     <% end %>
-    </section>
-  <% end %>
+  </div>
 </div>

--- a/app/views/shared/_header_old.html.erb
+++ b/app/views/shared/_header_old.html.erb
@@ -1,18 +1,29 @@
+<div class="mb-6 rounded-2xl bg-white/80 backdrop-blur shadow-lg border border-black/5 p-6">
+  <div class="mb-4">
+    <h2 class="text-lg font-semibold text-gray-900">
+      今日の貯金状況
+    </h2>
+  </div>
 
+  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-3">
+    <% items = [
+      ["日付", l(Date.current)],
+      ["1日の消費カロリー", "#{@bmr} kcal"],
+      ["本日の総カロリー", "#{@today_total} kcal"],
+      ["貯金額", "#{@calorie_saved} kcal"],
+      ["目標貯金カロリー", "#{@calorie_goal} kcal"],
+    ] %>
 
-<div class="grid grid-cols-2 md:grid-cols-5 gap-2 w-full">
-  <% items = [
-    ["日付", l(Date.current)],
-    ["1日の消費カロリー",  "#{@bmr} kcal"],
-    ["本日の総カロリー", "#{@today_total} kcal"],
-    ["貯金額", "#{@calorie_saved} kcal"],
-    ["目標貯金カロリー", "#{@calorie_goal} kcal"],
-  ] %>
+    <% items.each do |label, value| %>
+      <div class="rounded-xl border border-orange-100 bg-white/80 px-4 py-3 min-h-[76px]">
+        <div class="text-xs text-gray-500">
+          <%= label %>
+        </div>
 
-  <% items.each do |label, value| %>
-    <div class="border border-gray-300 rounded-md bg-white px-4 py-3 min-h-[72px]">
-      <div class="text-xs text-gray-500"><%= label %></div>
-      <div class="text-lg font-semibold"><%= value %></div>
-    </div>
-  <% end %>
+        <div class="mt-1 text-lg font-semibold text-gray-900">
+          <%= value %>
+        </div>
+      </div>
+    <% end %>
+  </div>
 </div>


### PR DESCRIPTION
## 概要
ログイン後トップページのUIを改善しました。

## 変更内容
- トップページ全体の表示幅と余白を調整
- 今日の貯金状況エリアのデザインを改善
- 食事ごとの記録カードのレイアウトを調整
- 「記録する」リンクの見た目を調整

## 確認方法
- ログイン後トップページが中央寄せで表示されること
- 今日の貯金状況が表示されること
- 朝食・昼食・夕食・おやつのカードが崩れず表示されること
- 「記録する」リンクから記録画面へ遷移できること

## 補足
累計貯金の表示については、別途実装予定です。