### PR TITLE
feat: カロリー入力フォームのUIを改善

### DIFF
--- a/app/views/calorie_records/_form.html.erb
+++ b/app/views/calorie_records/_form.html.erb
@@ -1,33 +1,43 @@
-<%= form_with model: calorie_record, local: true do |f| %>
+<div class="min-h-screen flex justify-center px-4 py-10">
+
+  <%= form_with model: calorie_record, local: true do |f| %>
     <%= f.hidden_field :meal_type, value: meal_type %>
     <%= f.hidden_field :image, value: calorie_record.cached_image_data %>
-  <div class="flex flex-col items-center space-y-4">
 
-    <div class="w-full max-w-sm">
-      <%= f.label :base_calorie, "カロリー", class: "block mb-1 text-sm font-medium" %>
-      <%= f.text_field :base_calorie,
-      inputmode: "numeric",
-      class: "w-full border rounded px-3 py-2" %>
+    <div class="moji w-full max-w-sm space-y-6 text-white">
+      <div>
+        <%= f.label :base_calorie, "カロリー", class: "block mb-1 text-sm" %>
+        <%= f.text_field :base_calorie,
+          inputmode: "numeric",
+          class: "w-full rounded-lg bg-white/90 text-gray-900 px-4 py-3" %>
+      </div>
+
+      <div>
+        <%= f.label :rice_bowls, "ご飯（杯）", class: "block mb-1 text-sm" %>
+        <%= f.number_field :rice_bowls,
+          min: 0,
+          class: "w-full rounded-lg bg-white/90 text-gray-900 px-4 py-3" %>
+      </div>
+
+      <div>
+        <%= f.label :memo, "メモ", class: "block mb-1 text-sm" %>
+        <%= f.text_area :memo,
+          rows: 4,
+          class: "w-full rounded-lg bg-white/90 text-gray-900 px-4 py-3" %>
+      </div>
+
+      <div>
+        <%= f.label :image, "画像", class: "block mb-1 text-sm" %>
+        <%= f.file_field :image,
+          class: "w-full rounded-lg bg-white/90 text-gray-900 px-4 py-3" %>
+      </div>
+
+      <div>
+        <%= f.submit "保存",
+          class: "w-full rounded-md bg-orange-400 px-6 py-3 text-white font-semibold hover:bg-orange-300" %>
+      </div>
+
     </div>
+  <% end %>
 
-    <div class="w-full max-w-sm">
-      <%= f.label :rice_bowls, "ご飯(杯)", class: "block mb-1 text-sm font-medium" %>
-      <%= f.number_field :rice_bowls, min: 0, class: "w-full border rounded px-3 py-2" %>
-    </div>
-
-    <div class="w-full max-w-sm">
-      <%= f.label :memo, "メモ", class: "block mb-1 text-sm font-medium" %>
-      <%= f.text_area :memo, class: "w-full border rounded px-3 py-2" %>
-    </div>
-
-    <div class="w-full max-w-sm">
-      <%= f.label :image, "画像", class: "block mb-1 text-sm font-medium" %>
-      <%= f.file_field :image, class: "w-full border rounded px-3 py-2" %>
-    </div>
-
-    <div class="w-full max-w-sm">
-      <%= f.submit "保存", class: "w-full bg-indigo-600 text-white py-2 rounded" %>
-    </div>
-
-  </div>
-<% end %>
+</div>

--- a/app/views/calorie_records/new.html.erb
+++ b/app/views/calorie_records/new.html.erb
@@ -1,4 +1,4 @@
-<h1 class="text-xl text-center font-bold mb-4">
-  <%= @meal_type %> のカロリー入力
+<h1 class="moji text-white text-xl text-center font-bold mb-4">
+  <%= @meal_type %>
 </h1>
 <%= render "form", calorie_record: @calorie_record, meal_type: @meal_type %>


### PR DESCRIPTION
## 概要
カロリー入力フォームのUIを改善しました。

## 変更内容
- フォーム全体のレイアウトを見直し、中央寄せに変更
- 外枠（カード）を廃止し、シンプルなデザインに変更
- 入力欄のデザインを調整（背景・余白・角丸）
- フォームの横幅を調整し、視認性を向上
- 保存ボタンのデザインをトップページと統一（オレンジ系）
- 全体の配色と余白を整理

## 確認方法
1. ログインする  
2. カロリー入力ページ（新規作成画面）へ遷移する  
3. 以下を確認  
   - フォームが中央に表示される  
   - 入力欄が見やすいデザインになっている  
   - 保存ボタンがオレンジ色で表示される  
   - レイアウトがシンプルになっている  
