### PR TITLE
feat: 食事種別の日本語表示とフォーム余白を調整

### DIFF
--- a/app/views/calorie_records/new.html.erb
+++ b/app/views/calorie_records/new.html.erb
@@ -1,4 +1,11 @@
-<h1 class="moji text-white text-xl text-center font-bold mb-4">
-  <%= @meal_type %>
-</h1>
-<%= render "form", calorie_record: @calorie_record, meal_type: @meal_type %>
+<div class="min-h-screen flex justify-center px-4 py-15">
+  <div class="w-full max-w-sm space-y-1 text-white">
+
+    <h1 class="moji text-3xl text-center font-bold">
+      <%= t("activerecord.attributes.calorie_record.meal_type.#{@meal_type}") %>の記録
+    </h1>
+
+    <%= render "form", calorie_record: @calorie_record, meal_type: @meal_type %>
+
+  </div>
+</div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,1 +1,9 @@
-ja: {}
+ja:
+  activerecord:
+    attributes:
+      calorie_record:
+        meal_type:
+          breakfast: 朝食
+          lunch: 昼食
+          dinner: 夕食
+          snack: 間食


### PR DESCRIPTION
## 概要
食事別カロリー入力フォームの日本語化とフォーム余白を調整しました

## 変更内容
- enumを日本語化にするために、ja.ymlファイルに追記
- フォームの余白を調整
## 確認方法
- ログイン
- 各食事のカロリー入力フォームのタイトルが日本語になっているか
