### PR TITLE
fix: 進捗バー計算時のゼロ除算エラーを修正

### DIFF
--- a/app/views/shared/_header_old.html.erb
+++ b/app/views/shared/_header_old.html.erb
@@ -28,7 +28,13 @@
     <% end %>
   </div>
 
-  <% progress = (@total_saved_calorie.to_f / @calorie_goal.to_f * 100).clamp(0, 100) %>
+  <% progress =
+    if @calorie_goal.to_i > 0
+      (@total_saved_calorie.to_f / @calorie_goal.to_f * 100).clamp(0, 100)
+    else
+      0
+    end
+  %>
 
   <div class="mt-3">
     <div class="flex justify-between text-xl mb-1">


### PR DESCRIPTION
## 概要
進捗バー表示時に発生していたエラーを修正しました。

## 変更内容
- 目標カロリーが0の場合に発生するゼロ除算エラーを修正
- 進捗率計算時にガード処理を追加し、目標未設定時は0%を表示するように変更

## 確認方法
1. ログインする  
2. トップページを表示する  
3. 以下を確認  
   - エラーが発生せず画面が表示される  
   - 目標カロリーが0の場合、進捗バーが0%で表示される  
   - 目標カロリーが設定されている場合、正常に進捗率が表示される  