### PR TITLE
feat: フラッシュメッセージの自動フェードアウトと中央配置

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -69,3 +69,11 @@
   font-style: normal;
 }
 
+@keyframes fadeOut {
+  0% { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+.flash-message {
+  animation: fadeOut 0.5s ease-in-out 3s forwards;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -46,6 +46,7 @@
             </div>
           <% end %>
     </div>
+  </div>
     <%= render "shared/footer" %>
 </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,25 +37,15 @@
         <%= yield %>
       </main>
 
-    <!-- フラッシュメッセージ -->
-    <div class="fixed top-4 right-4 z-50">
-      <% flash.each do |message_type, message| %>
-        <div class="px-4 py-3 rounded-lg shadow-lg text-sm font-medium
-          <%= message_type == 'notice' ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800' %>">
-          <%= message %>
-        </div>
-      <% end %>
+      <!-- フラッシュメッセージ -->
+    <div class="fixed top-4 left-1/2 transform -translate-x-1/2 z-50">
+          <% flash.each do |message_type, message| %>
+            <div class="flash-message px-4 py-3 rounded-lg shadow-lg text-sm font-medium
+                <%= message_type == 'notice' ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800' %>">
+                <%= message %>
+            </div>
+          <% end %>
     </div>
-
-  </div>
-    <div class="fixed top-4 right-4 z-50">
-      <% flash.each do |message_type, message| %>
-      <div class="px-4 py-3 rounded-lg shadow-lg text-sm font-medium
-      <%= message_type == 'notice' ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800' %>">
-      <%= message %>
-        </div>
-      <% end %>
-  </div>
     <%= render "shared/footer" %>
 </body>
 </html>


### PR DESCRIPTION
## 概要
フラッシュメッセージを画面中央に配置し、3秒後に自動でフェードアウトするようにしました。

## 変更内容
- フラッシュメッセージの表示位置を右上から中央上部に変更
- CSSアニメーションで3秒後に自動フェードアウト