### PR TITLE
fix: 本番環境のメールURL生成設定を追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,4 +102,9 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+
+  config.action_mailer.default_url_options = {
+    host: "calorie-bank.onrender.com",
+    protocol: "https"
+  }
 end


### PR DESCRIPTION
### 概要
本番環境での、パスワードリセットメール送信時のエラーを解消しました。

### 変更内容
- config/environments/production.rbにdefault_url_optionsを追加

### 原因
- 本番環境に、メール内のURLを作るための host 設定が足りなかった