### PR TITLE
fix: 未使用のDevise passwordsルーティングを削除

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,6 @@ Rails.application.routes.draw do
   devise_for :users, controllers: {
     sessions: "users/sessions",
     omniauth_callbacks: "users/omniauth_callbacks",
-    passwords: "users/passwords"
   }
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: "/letter_opener"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
     sessions: "users/sessions",
-    omniauth_callbacks: "users/omniauth_callbacks",
+    omniauth_callbacks: "users/omniauth_callbacks"
   }
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: "/letter_opener"


### PR DESCRIPTION
### 概要
パスワード再設定画面へのルーティングエラーが出ていたので、解消しました。

### 変更内容
- 未使用のDevise passwordsルーティングを削除