### PR TITLE
feat: タイムゾーンを東京に設定

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,5 +25,6 @@ module App
     # config.eager_load_paths << Rails.root.join("extras")
 
     config.i18n.default_locale = :ja
+    config.time_zone = "Tokyo"
   end
 end


### PR DESCRIPTION
## 概要
タイムゾーンを東京に設定しました。

## 目的
Date.currentを使って、日時を取得していたが
地域の設定をしておらず、UTCで統一されており、
ログインした際の日付にズレが生じていました。

## 変更内容
・config/application.rbに``` config.time_zone = "Tokyo" ```を追加