### PR TITLE
chore: 許可するホストを追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,6 +3,8 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   config.hosts << "caloriebank.jp"
   config.hosts << "www.caloriebank.jp"
+  config.hosts << "calorie-bank.onrender.com"
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.


### PR DESCRIPTION
## 概要
デプロイエラーが発生したので、その解決をしました。

## エラー内容
config.hostsを書いたことにより、リストにあるホストだけを許可するという形になっていたが、`config.hosts << "calorie-bank.onrender.com"`を書いていなかった為、デプロイエラーが発生しました。

## 変更内容
`config.hosts << "calorie-bank.onrender.com"`を追記しました。